### PR TITLE
Story/geco 20 Digilib REST endpoint should be callable without access token

### DIFF
--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/RestSecurityAspect.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/RestSecurityAspect.java
@@ -255,6 +255,7 @@ public class RestSecurityAspect {
                 Parameter p = paras[i];
                 if (p.getAnnotation(InjectImagePath.class) != null) {
                     imagePathParamIdx = i;
+                    break;
                 }
             }
 

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/RestSecurityAspect.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/RestSecurityAspect.java
@@ -1,12 +1,9 @@
 package edu.asu.diging.gilesecosystem.web.aspects.access;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.List;
@@ -263,14 +260,12 @@ public class RestSecurityAspect {
 
             if (imagePathParamIdx != -1) {
 
-                String imagePath = extractImagePath(joinPoint);
+                String imagePath = (String) arguments[imagePathParamIdx];
                 
                 IFile file = filesManager.getFileByPath(imagePath);
                 if (file == null) {
                     return new ResponseEntity<String>(HttpStatus.NOT_FOUND);
                 }
-                // Inject the image path at the index
-                arguments[imagePathParamIdx] = imagePath;
                 
                 if (file.getAccess() == DocumentAccess.PUBLIC) {
                     return joinPoint.proceed(arguments);
@@ -487,42 +482,6 @@ public class RestSecurityAspect {
         }
         
         return new ResponseEntity<String>(sw.toString(), status);
-    }
-    
-    private String extractImagePath(ProceedingJoinPoint joinPoint) throws UnsupportedEncodingException {
-        Object[] args = joinPoint.getArgs();
-        MethodSignature sig = (MethodSignature) joinPoint.getSignature();
-        String[] argNames = sig.getParameterNames();
-        Class<?>[] argTypes = sig.getParameterTypes();
-        
-        String imagePath = null;
-        for (int i = 0; i < argNames.length; i++) {
-            if (HttpServletRequest.class.isAssignableFrom(argTypes[i])) {
-                Map<String, String[]> parameters = ((HttpServletRequest)args[i]).getParameterMap();
-                
-                StringBuffer parameterBuffer = new StringBuffer();
-                for (String key : parameters.keySet()) {
-                    for (String value : parameters.get(key)) {
-                        parameterBuffer.append(key);
-                        parameterBuffer.append("=");
-
-                        parameterBuffer.append(URLEncoder.encode(value, "UTF-8"));
-                        parameterBuffer.append("&");
-
-                        if (key.equals("fn")) {
-                            imagePath = value;
-                        }
-                    }
-                }
-            }
-        }
-        
-        if (imagePath != null && imagePath.startsWith(File.separator)) {
-            imagePath = imagePath.substring(1);
-        }
-        
-        return imagePath;
-        
     }
     
     

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/annotations/ImageAccessCheck.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/annotations/ImageAccessCheck.java
@@ -1,0 +1,12 @@
+package edu.asu.diging.gilesecosystem.web.aspects.access.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ImageAccessCheck {
+    String value() default "accessToken";
+}

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/annotations/InjectImagePath.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/aspects/access/annotations/InjectImagePath.java
@@ -1,0 +1,12 @@
+package edu.asu.diging.gilesecosystem.web.aspects.access.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface InjectImagePath {
+    
+}

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
@@ -23,7 +23,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import edu.asu.diging.gilesecosystem.web.aspects.access.annotations.ImageAccessCheck;
-import edu.asu.diging.gilesecosystem.web.aspects.access.annotations.TokenCheck;
 import edu.asu.diging.gilesecosystem.web.core.DocumentAccess;
 import edu.asu.diging.gilesecosystem.web.core.IFile;
 import edu.asu.diging.gilesecosystem.web.files.IFilesManager;

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
@@ -50,7 +50,7 @@ public class DigilibPassthroughController {
             HttpServletRequest request, 
             HttpServletResponse response,
             User user,
-            @InjectImagePath String fn)
+            @RequestParam(defaultValue = "") @InjectImagePath String fn)
             throws UnsupportedEncodingException {
         
         IFile file = filesManager.getFileByPath(fn);

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/DigilibPassthroughController.java
@@ -22,6 +22,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import edu.asu.diging.gilesecosystem.web.aspects.access.annotations.ImageAccessCheck;
 import edu.asu.diging.gilesecosystem.web.aspects.access.annotations.TokenCheck;
 import edu.asu.diging.gilesecosystem.web.core.DocumentAccess;
 import edu.asu.diging.gilesecosystem.web.core.IFile;
@@ -41,7 +42,7 @@ public class DigilibPassthroughController {
     @Autowired
     private DigilibConnector digilibConnector;
 
-    @TokenCheck
+    @ImageAccessCheck
     @RequestMapping(value = "/rest/digilib")
     public ResponseEntity<String> passthroughToDigilib(
             @RequestParam(defaultValue = "") String accessToken,


### PR DESCRIPTION
Tried to send file object from aspect to calling method, but calling method needs parameterBuffer to pass it to digitallibImage function. Even if we get file object from aspect, we need to read get parameters again in order to create parameterBuffer. Please let me know if this is ok.