### PR TITLE
[GECO-106] make only one db call for page files (#70)

### DIFF
--- a/giles-eco/pom.xml
+++ b/giles-eco/pom.xml
@@ -118,11 +118,6 @@
             <artifactId>util</artifactId>
             <version>${geco.util.version}</version>
         </dependency>
-        <dependency>
-            <groupId>edu.asu.diging.giles-eco</groupId>
-            <artifactId>september-util</artifactId>
-            <version>${geco.september.util.version}</version>
-        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/controllers/ViewDocumentController.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/controllers/ViewDocumentController.java
@@ -105,44 +105,55 @@ public class ViewDocumentController {
         docBean.setTextFiles(new ArrayList<>());
         docBean.setMetadataUrl(metadataService.getDocumentLink(doc));
         docBean.setPages(new ArrayList<>());
-
+        
+        List<String> ids = new ArrayList<>();
+        docBean.getTasks().forEach(t -> {
+            if (t.getResultFileId() != null) {
+                ids.add(t.getResultFileId());
+            }
+        });
+        Map<String, IFile> additionalFilesMap = fileService.getFilesForIds(ids);
+        
+        
         IFile origFile = fileService.getFileById(doc.getUploadedFileId());
         if (origFile != null) {
             FilePageBean bean = createFilePageBean(fileMappingService, requestsByFileId,
-                    badgesByFile, origFile, docBean.getTasks());
+                    badgesByFile, origFile, docBean.getTasks(), additionalFilesMap);
             docBean.setUploadedFile(bean);
         }
 
         IFile textFile = fileService.getFileById(doc.getExtractedTextFileId());
         if (textFile != null) {
             FilePageBean bean = createFilePageBean(fileMappingService, requestsByFileId,
-                    badgesByFile, textFile, docBean.getTasks());
+                    badgesByFile, textFile, docBean.getTasks(), additionalFilesMap);
             docBean.setExtractedTextFile(bean);
         }
-
+        
         for (IPage page : doc.getPages()) {
             PagePageBean bean = pageMappingService.convertToT2(page, new PagePageBean());
             docBean.getPages().add(bean);
+            
+            Map<String, IFile> pageFiles = fileService.getFilesForPage(page);
 
-            IFile imageFile = fileService.getFileById(page.getImageFileId());
+            IFile imageFile = pageFiles.get(page.getImageFileId());
             if (imageFile != null) {
                 FilePageBean pageBean = createFilePageBean(fileMappingService,
-                        requestsByFileId, badgesByFile, imageFile, docBean.getTasks());
+                        requestsByFileId, badgesByFile, imageFile, docBean.getTasks(), additionalFilesMap);
                 bean.setImageFile(pageBean);
 
             }
 
-            IFile pageTextFile = fileService.getFileById(page.getTextFileId());
+            IFile pageTextFile = pageFiles.get(page.getTextFileId());
             if (pageTextFile != null) {
                 FilePageBean textBean = createFilePageBean(fileMappingService,
-                        requestsByFileId, badgesByFile, pageTextFile, docBean.getTasks());
+                        requestsByFileId, badgesByFile, pageTextFile, docBean.getTasks(), additionalFilesMap);
                 bean.setTextFile(textBean);
             }
 
-            IFile ocrFile = fileService.getFileById(page.getOcrFileId());
+            IFile ocrFile = pageFiles.get(page.getOcrFileId());
             if (ocrFile != null) {
                 FilePageBean ocrBean = createFilePageBean(fileMappingService,
-                        requestsByFileId, badgesByFile, ocrFile, docBean.getTasks());
+                        requestsByFileId, badgesByFile, ocrFile, docBean.getTasks(), additionalFilesMap);
                 bean.setOcrFile(ocrBean);
             }
         }
@@ -153,19 +164,20 @@ public class ViewDocumentController {
     private FilePageBean createFilePageBean(
             IGilesMappingService<IFile, FilePageBean> fileMappingService,
             Map<String, List<IProcessingRequest>> requestsByFileId,
-            Map<String, List<Badge>> badgesByFile, IFile file, List<ITask> tasks)
+            Map<String, List<Badge>> badgesByFile, IFile file, List<ITask> tasks, Map<String, IFile> additionalFiles)
             throws GilesMappingException {
         FilePageBean pageBean = fileMappingService.convertToT2(file, new FilePageBean());
         pageBean.setMetadataLink(metadataService.getFileLink(file));
         setRequestStatus(pageBean, requestsByFileId);
         pageBean.setBadges(badgesByFile.get(pageBean.getId()));
-        addAdditionalFiles(pageBean, tasks, requestsByFileId);
+        addAdditionalFiles(pageBean, tasks, requestsByFileId, additionalFiles);
         return pageBean;
     }
 
-    private void addAdditionalFiles(FilePageBean bean, List<ITask> tasks, Map<String, List<IProcessingRequest>> requestsByFileId) {
+    private void addAdditionalFiles(FilePageBean bean, List<ITask> tasks, 
+            Map<String, List<IProcessingRequest>> requestsByFileId, Map<String, IFile> additionalFiles) {
         tasks.forEach(t -> {
-            IFile additionalFile = fileService.getFileById(t.getResultFileId());
+            IFile additionalFile = additionalFiles.get(t.getResultFileId());
             if (additionalFile != null) {   
                 if (bean.getId().equals(additionalFile.getDerivedFrom())) {
                     AdditionalFilePageBean additionalFileBean = new AdditionalFilePageBean(t.getResultFileId(),

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/controllers/util/StatusBadgeHelper.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/controllers/util/StatusBadgeHelper.java
@@ -49,7 +49,7 @@ public class StatusBadgeHelper {
         if (procRequests.stream()
                 .filter(preq -> preq.getSentRequest() instanceof ITextExtractionRequest)
                 .count() > 0) {
-            RequestStatus status = statusHelper.getProcessingPhaseResult(ITextExtractionRequest.class, docBean);
+            RequestStatus status = statusHelper.getProcessingPhaseResult(ITextExtractionRequest.class, procRequests);
             docBean.getBadges()
                 .add(new Badge(
                     propertiesManager
@@ -64,7 +64,7 @@ public class StatusBadgeHelper {
         if (procRequests.stream()
                 .filter(preq -> preq.getSentRequest() instanceof IImageExtractionRequest)
                 .count() > 0) {
-            RequestStatus status = statusHelper.getProcessingPhaseResult(IImageExtractionRequest.class, docBean);
+            RequestStatus status = statusHelper.getProcessingPhaseResult(IImageExtractionRequest.class, procRequests);
             docBean.getBadges()
                 .add(new Badge(
                     propertiesManager
@@ -80,7 +80,7 @@ public class StatusBadgeHelper {
         if (procRequests.stream()
                 .filter(preq -> preq.getSentRequest() instanceof IOCRRequest)
                 .count() > 0) {
-            RequestStatus status = statusHelper.getProcessingPhaseResult(IOCRRequest.class, docBean);
+            RequestStatus status = statusHelper.getProcessingPhaseResult(IOCRRequest.class, procRequests);
             docBean.getBadges()
                 .add(new Badge(
                     propertiesManager

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/IFilesDatabaseClient.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/IFilesDatabaseClient.java
@@ -24,4 +24,6 @@ public interface IFilesDatabaseClient extends IDatabaseClient<IFile> {
 
     List<IFile> getFilesByDerivedFrom(String derivedFromId);
 
+    List<IFile> getFilesForIds(List<String> ids);
+
 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/impl/FilesDatabaseClient.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/impl/FilesDatabaseClient.java
@@ -1,9 +1,11 @@
 package edu.asu.diging.gilesecosystem.web.files.impl;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
 
 import org.springframework.stereotype.Component;
 
@@ -40,6 +42,13 @@ public class FilesDatabaseClient extends DatabaseClient<IFile> implements
     @Override
     public IFile getFileById(String id) {
         return em.find(File.class, id);
+    }
+    
+    @Override
+    public List<IFile> getFilesForIds(List<String> ids) {
+        TypedQuery<IFile> query = getClient().createQuery("SELECT t FROM " + File.class.getName()  + " t WHERE t.id IN (:ids)", IFile.class);
+        query.setParameter("ids", ids);
+        return query.getResultList();
     }
 
     @Override

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/impl/ProcessingRequestsDatabaseClient.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/files/impl/ProcessingRequestsDatabaseClient.java
@@ -31,7 +31,9 @@ public class ProcessingRequestsDatabaseClient extends DatabaseClient<IProcessing
 
     @Override
     public List<IProcessingRequest> getRequestByDocumentId(String docId) {
-        return searchByProperty("documentId", docId, ProcessingRequest.class);
+        List<Object> results = getClient().createQuery("SELECT t FROM " + IProcessingRequest.class.getName()  + " t WHERE t.documentId = '" + docId + "'").getResultList();
+        TypedQuery<IProcessingRequest> query = getClient().createQuery("SELECT t FROM " + IProcessingRequest.class.getName()  + " t WHERE t.documentId = '" + docId + "'", IProcessingRequest.class);
+        return query.getResultList();
     }
     
     @Override

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/UploadImagesController.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/UploadImagesController.java
@@ -196,7 +196,7 @@ public class UploadImagesController {
                     "{\"error\": \"Could not write json result.\" }",
                     HttpStatus.INTERNAL_SERVER_ERROR);
         }
-
+        
         return new ResponseEntity<String>(sw.toString(), HttpStatus.OK);
     }
     

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/util/impl/JSONHelper.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/rest/util/impl/JSONHelper.java
@@ -84,18 +84,19 @@ public class JSONHelper implements IJSONHelper {
                 ObjectNode pageNode = pagesArray.addObject();
                 pageNode.put("nr", page.getPageNr());
                 ArrayNode additionalPageFiles = mapper.createArrayNode();
+                Map<String, IFile> pageFiles = fileService.getFilesForPage(page);
                 if (page.getImageFileId() != null) {
-                    IFile imageFile = fileService.getFileById(page.getImageFileId());
+                    IFile imageFile = pageFiles.get(page.getImageFileId());
                     pageNode.set("image", createFileJsonObject(mapper, imageFile));
                     addFiletoArray(mapper, tasksByDerivedFrom, imageFile, additionalPageFiles);
                 }
                 if (page.getTextFileId() != null) {
-                    IFile textFile = fileService.getFileById(page.getTextFileId());
+                    IFile textFile = pageFiles.get(page.getTextFileId());
                     pageNode.set("text", createFileJsonObject(mapper, textFile));
                     addFiletoArray(mapper, tasksByDerivedFrom, textFile, additionalPageFiles);
                 }
                 if (page.getOcrFileId() != null) {
-                    IFile ocrFile = fileService.getFileById(page.getOcrFileId());
+                    IFile ocrFile = pageFiles.get(page.getOcrFileId());
                     pageNode.set("ocr", createFileJsonObject(mapper, ocrFile));
                     addFiletoArray(mapper, tasksByDerivedFrom, ocrFile, additionalPageFiles);
                 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/service/core/ITransactionalFileService.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/service/core/ITransactionalFileService.java
@@ -1,9 +1,11 @@
 package edu.asu.diging.gilesecosystem.web.service.core;
 
 import java.util.List;
+import java.util.Map;
 
 import edu.asu.diging.gilesecosystem.util.exceptions.UnstorableObjectException;
 import edu.asu.diging.gilesecosystem.web.domain.IFile;
+import edu.asu.diging.gilesecosystem.web.domain.IPage;
 
 public interface ITransactionalFileService {
 
@@ -22,5 +24,9 @@ public interface ITransactionalFileService {
     String generateRequestId(String prefix);
 
     List<IFile> getFilesByDerivedFrom(String derivedFromId);
+
+    Map<String, IFile> getFilesForPage(IPage page);
+
+    Map<String, IFile> getFilesForIds(List<String> ids);
 
 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/service/core/impl/TransactionalFileService.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/service/core/impl/TransactionalFileService.java
@@ -1,6 +1,10 @@
 package edu.asu.diging.gilesecosystem.web.service.core.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -8,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import edu.asu.diging.gilesecosystem.util.exceptions.UnstorableObjectException;
 import edu.asu.diging.gilesecosystem.web.domain.IFile;
+import edu.asu.diging.gilesecosystem.web.domain.IPage;
 import edu.asu.diging.gilesecosystem.web.files.IFilesDatabaseClient;
 import edu.asu.diging.gilesecosystem.web.service.core.ITransactionalFileService;
 
@@ -49,6 +54,32 @@ public class TransactionalFileService implements ITransactionalFileService {
             return null;
         }
         return filesDbClient.getFileById(id);
+    }
+    
+    @Override
+    public Map<String, IFile> getFilesForPage(IPage page) {
+        List<String> ids = new ArrayList<>();
+        if (page.getImageFileId() != null) {
+            ids.add(page.getImageFileId());
+        }
+        if (page.getOcrFileId() != null) {
+            ids.add(page.getOcrFileId());
+        }
+        if (page.getTextFileId() != null) {
+            ids.add(page.getTextFileId());
+        }
+        return getFilesForIds(ids);
+    }
+    
+    @Override
+    public Map<String, IFile> getFilesForIds(List<String> ids) {
+        Map<String, IFile> fileMap = new HashMap<>();
+        if (ids == null || ids.isEmpty()) {
+            return fileMap;
+        }
+        List<IFile> files = filesDbClient.getFilesForIds(ids);
+        files.forEach(f -> fileMap.put(f.getId(), f));
+        return fileMap;
     }
     
     @Override

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/util/IStatusHelper.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/util/IStatusHelper.java
@@ -1,9 +1,12 @@
 package edu.asu.diging.gilesecosystem.web.util;
 
+import java.util.List;
+
 import edu.asu.diging.gilesecosystem.requests.IRequest;
 import edu.asu.diging.gilesecosystem.requests.RequestStatus;
 import edu.asu.diging.gilesecosystem.web.domain.IDocument;
 import edu.asu.diging.gilesecosystem.web.domain.IFile;
+import edu.asu.diging.gilesecosystem.web.domain.IProcessingRequest;
 
 /**
  * Implementations of this interface provide support for calculating statuses of
@@ -32,7 +35,7 @@ public interface IStatusHelper {
      * if at least one of them submitted; otherwise it returns {@link RequestStatus.COMPLETE}.
      * 
      * @param requestClass The type of request that should be filtered on.
-     * @param document The document for which the processing phase result should be deteremined.
+     * @param procRequests The processing results used to determine the request status.
      * @return The request status of the document according to the conditions in the following order:
      * <ol>
      *  <li>{@link RequestStatus.FAILED}: if at least one request failed.</li>
@@ -41,7 +44,7 @@ public interface IStatusHelper {
      *  <li>{@link RequestStatus.COMPLETE}: in any other case.</li>
      * </ol>
      */
-    public abstract RequestStatus getProcessingPhaseResult(Class<? extends IRequest> requestClass, IDocument document);
+    public abstract RequestStatus getProcessingPhaseResult(Class<? extends IRequest> requestClass, List<IProcessingRequest> procRequests);
 
     /**
      * Method to get the processing status of a file. If there exist a request that has

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/util/impl/StatusHelper.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/util/impl/StatusHelper.java
@@ -61,10 +61,7 @@ public class StatusHelper implements IStatusHelper {
 
     @Override
     public RequestStatus getProcessingPhaseResult(Class<? extends IRequest> requestClass,
-            IDocument document) {
-        List<IProcessingRequest> procRequests = procReqDbClient
-                .getRequestByDocumentId(document.getId());
-
+            List<IProcessingRequest> procRequests) {
         if (procRequests
                 .stream()
                 .filter(preq -> requestClass.isAssignableFrom(preq.getSentRequest()

--- a/giles-eco/src/main/resources/config.properties
+++ b/giles-eco/src/main/resources/config.properties
@@ -14,7 +14,8 @@ hibernate.format_sql=true
 # Zookeeper
 zookeeper_host=${zookeeper.host}
 zookeeper_port=${zookeeper.port}
-zookeeepr_service_nepomuk_name=nepomuk
+zookeeper_service_name=giles
+zookeeper_service_root=/services
 
 # Nepomuk
 nepomuk_ping_endpoint=/rest/ping
@@ -45,6 +46,7 @@ jwt_signing_secret_apps=${jwt.signing.secret.apps}
 
 digilib_scaler_url=${digilib.url}
 giles_url=${giles.base.url}
+app_base_url=${giles.base.url}
 giles_digilib_endpoint=/rest/digilib
 giles_file_endpoint=/rest/files/
 giles_check_upload_endpoint=/rest/files/upload/check/


### PR DESCRIPTION
* [GECO-106] make only one db call for page files

Make one call to DB to retrieve files that are linked from pages; also
adjustments for new geco kafka plugin

* [GECO-106] condense db calls for web ui

* [GECO-106] Fix error caused by no additional files

* [GECO-106] don't pass null into db retrieval method