### PR TITLE
GECO-100 : Send emails to users on account activation/revoke

### DIFF
--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/IEmailNotificationManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/IEmailNotificationManager.java
@@ -21,4 +21,6 @@ public interface IEmailNotificationManager {
      */
     void sendAccountCreatedEmail(String name, String username, String adminName, String adminEmail)
             throws GilesNotificationException;
+    
+    void sendAccountApprovalOrRevokeEmail(String name, String userName, String userEmail, boolean approved) throws GilesNotificationException;
 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/IEmailNotificationManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/IEmailNotificationManager.java
@@ -21,6 +21,25 @@ public interface IEmailNotificationManager {
      */
     void sendAccountCreatedEmail(String name, String username, String adminName, String adminEmail)
             throws GilesNotificationException;
+
+    /**
+     * Send account approval email to the user
+     *
+     * @param name name of new user
+     * @param userName userName of new user
+     * @param userEmail email id of user
+     * @throws GilesNotificationException
+     */
+    void sendAccountApprovalEmail(String name, String userName, String userEmail) throws GilesNotificationException;
+
+    /**
+     * Send account revoked email to the user
+     *
+     * @param name name of new user
+     * @param userName userName of new user
+     * @param userEmail email id of user
+     * @throws GilesNotificationException
+     */
+    void sendAccountRevokedEmail(String name, String userName, String userEmail) throws GilesNotificationException;
     
-    void sendAccountApprovalOrRevokeEmail(String name, String userName, String userEmail, boolean approved) throws GilesNotificationException;
 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/impl/EmailNotificationManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/impl/EmailNotificationManager.java
@@ -52,5 +52,35 @@ public class EmailNotificationManager implements IEmailNotificationManager {
             throw new GilesNotificationException(e);
         }
     }
+    
+    @Override
+    public void sendAccountApprovalOrRevokeEmail(String name, String userName, String userEmail, boolean approved) 
+            throws GilesNotificationException {
+        Map<String, Object> contextProperties = new HashMap<String, Object>();
+        contextProperties.put("name", name);
+        contextProperties.put("userName", userName);
+        String msg;
+        String subject;
+        try {
+            if (approved) {
+                msg = velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountApproved.vm",
+                        contextProperties);
+                subject = emailMessages.getMessage("email.account_approved.subject", new String[]{}, null);
+            } else {
+                msg = velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountRevoked.vm",
+                        contextProperties);
+                subject = emailMessages.getMessage("email.account_revoked.subject", new String[]{}, null);
+            }
+            emailSender.sendNotificationEmail(userEmail, subject, msg);
+        } catch (ResourceNotFoundException e) {
+            throw new GilesNotificationException(e);
+        } catch (ParseErrorException e) {
+            throw new GilesNotificationException(e);
+        } catch (Exception e) {
+            //getTemplate method call under getRenderedTemplate can throw exception
+            throw new GilesNotificationException(e);
+        }
+        
+    }
 
 }

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/impl/EmailNotificationManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/email/impl/EmailNotificationManager.java
@@ -48,36 +48,43 @@ public class EmailNotificationManager implements IEmailNotificationManager {
         } catch (ParseErrorException e) {
             throw new GilesNotificationException(e);
         } catch (Exception e) {
-            //getTemplate method call under getRenderedTemplate can throw exception
             throw new GilesNotificationException(e);
         }
     }
     
     @Override
-    public void sendAccountApprovalOrRevokeEmail(String name, String userName, String userEmail, boolean approved) 
+    public void sendAccountApprovalEmail(String name, String userName, String userEmail) 
             throws GilesNotificationException {
         Map<String, Object> contextProperties = new HashMap<String, Object>();
         contextProperties.put("name", name);
         contextProperties.put("userName", userName);
-        String msg;
-        String subject;
         try {
-            if (approved) {
-                msg = velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountApproved.vm",
-                        contextProperties);
-                subject = emailMessages.getMessage("email.account_approved.subject", new String[]{}, null);
-            } else {
-                msg = velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountRevoked.vm",
-                        contextProperties);
-                subject = emailMessages.getMessage("email.account_revoked.subject", new String[]{}, null);
-            }
-            emailSender.sendNotificationEmail(userEmail, subject, msg);
+            emailSender.sendNotificationEmail(userEmail, emailMessages.getMessage("email.account_approved.subject", new String[]{}, null), 
+                    velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountApproved.vm", contextProperties));
         } catch (ResourceNotFoundException e) {
             throw new GilesNotificationException(e);
         } catch (ParseErrorException e) {
             throw new GilesNotificationException(e);
         } catch (Exception e) {
-            //getTemplate method call under getRenderedTemplate can throw exception
+            throw new GilesNotificationException(e);
+        }
+        
+    }
+    
+    @Override
+    public void sendAccountRevokedEmail(String name, String userName, String userEmail) 
+            throws GilesNotificationException {
+        Map<String, Object> contextProperties = new HashMap<String, Object>();
+        contextProperties.put("name", name);
+        contextProperties.put("userName", userName);
+        try {
+            emailSender.sendNotificationEmail(userEmail, emailMessages.getMessage("email.account_revoked.subject", new String[]{}, null), 
+                    velocityBuilder.getRenderedTemplate("velocitytemplates/email/accountRevoked.vm", contextProperties));
+        } catch (ResourceNotFoundException e) {
+            throw new GilesNotificationException(e);
+        } catch (ParseErrorException e) {
+            throw new GilesNotificationException(e);
+        } catch (Exception e) {
             throw new GilesNotificationException(e);
         }
         

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
@@ -147,6 +147,16 @@ public class UsersManager implements IUserManager {
             user.getRoles().add(GilesRole.ROLE_USER.name());
         }
         client.update(user);
+        try {
+            if (user.getEmail() != null && !user.getEmail().equals("")) {
+                System.out.println("Sending mail to " + user.getEmail());
+                emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), true);
+            }
+        } catch (GilesNotificationException e) {
+            // let's log warning but keep on going
+            messageHandler.handleMessage("Email to " + user.getUsername() + " could not be sent.", e, MessageType.WARNING);
+        }
+        
     }
     
     @Override
@@ -155,6 +165,16 @@ public class UsersManager implements IUserManager {
         user.setAccountStatus(AccountStatus.REVOKED);
         user.setRoles(new ArrayList<String>());
         client.update(user);
+        try {
+            if (user.getEmail() != null && !user.getEmail().equals("")) {
+                System.out.println("Sending mail to " + user.getEmail());
+                emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), false);
+            }
+        } catch (GilesNotificationException e) {
+            // let's log warning but keep on going
+            messageHandler.handleMessage("Email to " + user.getUsername() + " could not be sent.", e, MessageType.WARNING);
+        }
+        
     }
     
     @Override

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
@@ -149,7 +149,6 @@ public class UsersManager implements IUserManager {
         client.update(user);
         try {
             if (user.getEmail() != null && !user.getEmail().equals("")) {
-                System.out.println("Sending mail to " + user.getEmail());
                 emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), true);
             }
         } catch (GilesNotificationException e) {
@@ -167,7 +166,6 @@ public class UsersManager implements IUserManager {
         client.update(user);
         try {
             if (user.getEmail() != null && !user.getEmail().equals("")) {
-                System.out.println("Sending mail to " + user.getEmail());
                 emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), false);
             }
         } catch (GilesNotificationException e) {

--- a/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
+++ b/giles-eco/src/main/java/edu/asu/diging/gilesecosystem/web/core/users/UsersManager.java
@@ -149,10 +149,9 @@ public class UsersManager implements IUserManager {
         client.update(user);
         try {
             if (user.getEmail() != null && !user.getEmail().equals("")) {
-                emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), true);
+                emailManager.sendAccountApprovalEmail(user.getName(), user.getUsername(), user.getEmail());
             }
         } catch (GilesNotificationException e) {
-            // let's log warning but keep on going
             messageHandler.handleMessage("Email to " + user.getUsername() + " could not be sent.", e, MessageType.WARNING);
         }
         
@@ -166,10 +165,9 @@ public class UsersManager implements IUserManager {
         client.update(user);
         try {
             if (user.getEmail() != null && !user.getEmail().equals("")) {
-                emailManager.sendAccountApprovalOrRevokeEmail(user.getName(), user.getUsername(), user.getEmail(), false);
+                emailManager.sendAccountRevokedEmail(user.getName(), user.getUsername(), user.getEmail());
             }
         } catch (GilesNotificationException e) {
-            // let's log warning but keep on going
             messageHandler.handleMessage("Email to " + user.getUsername() + " could not be sent.", e, MessageType.WARNING);
         }
         

--- a/giles-eco/src/main/resources/locale/messages.properties
+++ b/giles-eco/src/main/resources/locale/messages.properties
@@ -35,4 +35,6 @@ admin_user_change_password_failure=There was an error. Password could not be cha
 admin_user_change_password_not_allowed=Sorry, this action is not allowed.
 
 email.account_created.subject = A new account has been created in Giles!
-email.tail = \n\n------------------------------------------------------------------------------------------------------------\nThis message was sent from Giles. Please don't reply to this message; it's automated and not monitored for responses. 
+email.tail = \n\n------------------------------------------------------------------------------------------------------------\nThis message was sent from Giles. Please don't reply to this message; it's automated and not monitored for responses.
+email.account_approved.subject = Your Giles Account has been approved
+email.account_revoked.subject = Your Giles Account has been revoked

--- a/giles-eco/src/main/resources/user.properties
+++ b/giles-eco/src/main/resources/user.properties
@@ -1,1 +1,1 @@
-admin=${admin.pw},ROLE_ADMIN,enabled
+admin=${admin.password},ROLE_ADMIN,enabled

--- a/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
+++ b/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
@@ -1,5 +1,5 @@
 Hi $name:
 
-Your Giles account has been approved by the admin! You can now login to Giles at http://$giles_url/ with $userName.
+Your Giles account has been approved. You can now login to Giles at http://$giles_url/ with $userName.
 
 Your Giles Team

--- a/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
+++ b/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
@@ -1,5 +1,5 @@
 Hi $name:
 
-Your Giles account has been approved by the admin! You can now login to Giles at http://$giles_url/ with '$username'.
+Your Giles account has been approved by the admin! You can now login to Giles at http://$giles_url/ with $userName.
 
 Your Giles Team

--- a/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
+++ b/giles-eco/src/main/resources/velocitytemplates/email/accountApproved.vm
@@ -1,0 +1,5 @@
+Hi $name:
+
+Your Giles account has been approved by the admin! You can now login to Giles at http://$giles_url/ with '$username'.
+
+Your Giles Team

--- a/giles-eco/src/main/resources/velocitytemplates/email/accountRevoked.vm
+++ b/giles-eco/src/main/resources/velocitytemplates/email/accountRevoked.vm
@@ -1,5 +1,5 @@
 Hi $name:
 
-Your Giles account request has been revoked by the admin!
+Your Giles account as been revoked. If you think this was an error please contact a Giles administrator.
 
 Your Giles Team

--- a/giles-eco/src/main/resources/velocitytemplates/email/accountRevoked.vm
+++ b/giles-eco/src/main/resources/velocitytemplates/email/accountRevoked.vm
@@ -1,0 +1,5 @@
+Hi $name:
+
+Your Giles account request has been revoked by the admin!
+
+Your Giles Team


### PR DESCRIPTION
1. Added templates for emails
2. Check if email is present or not before sending as I noticed citesphere clients might not have emails 
<img width="1285" alt="Screen Shot 2023-02-02 at 10 39 13" src="https://user-images.githubusercontent.com/37469232/216471082-d56ba4e8-1c68-449b-8e5b-0dc6de592091.png">







Emails Sent : 
<img width="1254" alt="Screenshot 2023-02-03 at 10 55 01 AM" src="https://user-images.githubusercontent.com/37469232/216693623-fd75d58c-305e-404a-a6bd-8de8c1de3445.png">
<img width="1270" alt="Screenshot 2023-02-03 at 10 55 16 AM" src="https://user-images.githubusercontent.com/37469232/216693629-7f31e0cc-c2a7-48cf-a370-1b89c038dfe6.png">

